### PR TITLE
Fix space key toggling while typing in description field

### DIFF
--- a/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
+++ b/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
@@ -237,8 +237,8 @@ public class SpringInitializrTui extends ToolkitApp {
             return EventResult.HANDLED;
         }
 
-        // Space — Toggle dependency
-        if (event.isChar(' ')) {
+        // Space — Toggle dependency (only when not editing a text field)
+        if (event.isChar(' ') && !isTextFieldFocused()) {
             mainScreen.toggleDependency();
             return EventResult.HANDLED;
         }


### PR DESCRIPTION
This prevents the space bar from triggering dependency selection when the user is editing the description field, allowing spaces to be typed normally in those inputs.