### PR TITLE
Fixed the backspace keyevent on Windows

### DIFF
--- a/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
+++ b/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
@@ -131,7 +131,7 @@ public class SpringInitializrTui extends ToolkitApp {
                 mainScreen.exitSearchMode();
                 return EventResult.HANDLED;
             }
-            if (event.isDeleteBackward()) {
+            if (isBackspace(event)) {
                 mainScreen.deleteSearchChar();
                 return EventResult.HANDLED;
             }
@@ -254,7 +254,7 @@ public class SpringInitializrTui extends ToolkitApp {
         }
 
         // Backspace — Delete char in text fields
-        if (event.isDeleteBackward()) {
+        if (isBackspace(event)) {
             mainScreen.handleBackspace();
             return EventResult.HANDLED;
         }
@@ -621,6 +621,18 @@ public class SpringInitializrTui extends ToolkitApp {
                         spacer()
                 ).length(1)
         );
+    }
+
+    /**
+     * Detects if the key event corresponds to a backspace action, accounting for different terminals sending different codes.
+     * The isDeleteBackward() method checks for the standard backspace key, while character code 104 corresponds to the backspace on Windows.
+     *
+     * @param event The key event to check
+     * @return true if the event is a backspace, false otherwise
+     */
+    private boolean isBackspace(KeyEvent event) {
+        return event.isDeleteBackward()
+          || event.character() == 104;
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
There is an issue with how backspace behaves in Windows Terminal. Instead of deleting the previous character, it was interpreted as a different control code and ended up inserting the letter “h” rather than removing the last character. This PR corrects it for the search field as well as for the Configuration text fields.
