### PR TITLE
Fix crash on launch in native profile executable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
                             <mainClass>${main.class}</mainClass>
                             <imageName>spring-initializr-tui</imageName>
                             <buildArgs>
+                                <arg>--initialize-at-build-time=dev.tamboui</arg>
                                 <arg>--enable-preview</arg>
                                 <arg>-H:+ReportExceptionStackTraces</arg>
                             </buildArgs>


### PR DESCRIPTION
On the latest release [v0.2.3](https://github.com/danvega/spring-initializr-tui/releases/tag/v0.2.3), the linux version seems to have an issue ( didn't test the macos or windows versions.).

The native executable (built via `mvn clean -Pnative package -DskipTests`) crashes on launch with 

```
Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class dev.tamboui.jfr.TerminalDrawEvent
        at dev.tamboui.terminal.Terminal.draw(Terminal.java:112)
        at dev.tamboui.tui.TuiRunner.renderErrorDisplay(TuiRunner.java:389)
        at dev.tamboui.tui.TuiRunner.handleRenderError(TuiRunner.java:332)
        at dev.tamboui.tui.TuiRunner.safeRender(TuiRunner.java:307)
        at dev.tamboui.tui.TuiRunner.run(TuiRunner.java:251)
        at dev.tamboui.toolkit.app.ToolkitRunner.run(ToolkitRunner.java:140)
        at dev.tamboui.toolkit.app.ToolkitApp.run(ToolkitApp.java:103)
        at dev.danvega.initializr.SpringInitializrTui.main(SpringInitializrTui.java:631)
        at java.base@25.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```


- Works fine with `mvn compile exec:java`

Fix:
added the `--initialize-at-build-time=dev.tamboui` build arguments for the native profile