### PR TITLE
Fix unexpected quit when typing 'q' during dependency search

### DIFF
--- a/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
+++ b/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
@@ -357,7 +357,9 @@ public class SpringInitializrTui extends ToolkitApp {
     }
 
     private boolean isTextFieldFocused() {
-        return mainScreen != null && switch (mainScreen.getFocusArea()) {
+        if (mainScreen == null) return false;
+
+        return mainScreen.isSearchMode() || switch (mainScreen.getFocusArea()) {
             case GROUP, ARTIFACT, NAME, DESCRIPTION -> true;
             default -> false;
         };


### PR DESCRIPTION
### Problem

When the focus area is `DEPENDENCIES`, typing `q` while searching for dependencies unexpectedly quits the application.

> For example, typing `postgresql` causes the application to exit when the `q` character is entered.

### Solution

Updated `SpringInitializrTui.isTextFieldFocused` to also check whether the main screen is in dependency search mode, preventing the quit handler from being triggered while typing in the search field. [SpringInitializrTui.java#L111](https://github.com/gymynnym/spring-initializr-tui/blob/e51633ca00d797004d9be00bce0bdc1f1afc7d29/src/main/java/dev/danvega/initializr/SpringInitializrTui.java#L111)

### Result

Typing `q` in dependency search (e.g. `postgresql`) no longer quits the application.