### PR TITLE
feat: refactored vim insert mode for text field

### DIFF
--- a/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
+++ b/src/main/java/dev/danvega/initializr/SpringInitializrTui.java
@@ -53,6 +53,8 @@ public class SpringInitializrTui extends ToolkitApp {
     // "Open in Terminal" — print cd command after TUI exits
     private volatile Path pendingTerminalDir;
 
+    private boolean vimInsertMode = false;
+
     @Override
     protected void onStart() {
         ThemeManager.setTheme(configStore.load().getTheme());
@@ -156,6 +158,20 @@ public class SpringInitializrTui extends ToolkitApp {
             return EventResult.UNHANDLED;
         }
 
+        // Esc — exit insert mode (before quit check steals it)
+        if (event.isCancel() && vimInsertMode) {
+            vimInsertMode = false;
+            mainScreen.setInsertMode(false);
+            return EventResult.HANDLED;
+        }
+
+        // i — enter insert mode when on a text field in normal mode
+        if (event.isChar('i') && !vimInsertMode && isOnTextFieldArea()) {
+            vimInsertMode = true;
+            mainScreen.setInsertMode(true);
+            return EventResult.HANDLED;
+        }
+
         // ? — Show help
         if (event.isChar('?') && !isTextFieldFocused()) {
             previousScreen = currentScreen;
@@ -197,6 +213,8 @@ public class SpringInitializrTui extends ToolkitApp {
 
         // Tab / Shift+Tab — Navigate focus (check both semantic and direct key)
         if (event.isFocusNext() || event.isKey(KeyCode.TAB)) {
+            vimInsertMode = false;
+            mainScreen.setInsertMode(false);
             if (event.hasShift()) {
                 mainScreen.focusPrevious();
             } else {
@@ -205,31 +223,65 @@ public class SpringInitializrTui extends ToolkitApp {
             return EventResult.HANDLED;
         }
         if (event.isFocusPrevious()) {
+            vimInsertMode = false;
+            mainScreen.setInsertMode(false);
             mainScreen.focusPrevious();
             return EventResult.HANDLED;
         }
 
-        // Arrow keys & Vim bindings — Up/Down also navigate between fields
-        if (event.isUp() || (event.hasCtrl() && event.isCharIgnoreCase('p')) 
-                || (event.isCharIgnoreCase('k') && !isTextFieldFocused())) {
+        // Arrow up — auto-insert when landing on a text field
+        if (event.isUp()) {
             if (mainScreen.getFocusArea() == MainScreen.FocusArea.DEPENDENCIES) {
                 if (mainScreen.getDependencyPicker().isAtTop()) {
                     mainScreen.focusPrevious();
+                    vimInsertMode = isOnTextFieldArea();
+                    mainScreen.setInsertMode(vimInsertMode);
                 } else {
                     mainScreen.getDependencyPicker().moveUp();
                 }
             } else {
                 mainScreen.focusPrevious();
+                vimInsertMode = isOnTextFieldArea();
+                mainScreen.setInsertMode(vimInsertMode);
             }
             return EventResult.HANDLED;
         }
-        if (event.isDown() || (event.hasCtrl() && event.isCharIgnoreCase('n')) 
-                || (event.isCharIgnoreCase('j') && !isTextFieldFocused())
-                || (event.isConfirm() && isTextFieldFocused())) {
+        // Vim k — stay in normal mode (no auto-insert)
+        if (event.isCharIgnoreCase('k') && !isTextFieldFocused()) {
+            if (mainScreen.getFocusArea() == MainScreen.FocusArea.DEPENDENCIES) {
+                if (mainScreen.getDependencyPicker().isAtTop()) {
+                    mainScreen.focusPrevious();
+                    vimInsertMode = false;
+                    mainScreen.setInsertMode(false);
+                } else {
+                    mainScreen.getDependencyPicker().moveUp();
+                }
+            } else {
+                mainScreen.focusPrevious();
+                vimInsertMode = false;
+                mainScreen.setInsertMode(false);
+            }
+            return EventResult.HANDLED;
+        }
+        // Arrow down + Enter-on-text-field — auto-insert when landing on a text field
+        if (event.isDown() || (event.isConfirm() && isTextFieldFocused())) {
             if (mainScreen.getFocusArea() == MainScreen.FocusArea.DEPENDENCIES) {
                 mainScreen.getDependencyPicker().moveDown();
             } else {
                 mainScreen.focusNext();
+                vimInsertMode = isOnTextFieldArea();
+                mainScreen.setInsertMode(vimInsertMode);
+            }
+            return EventResult.HANDLED;
+        }
+        // Vim j — stay in normal mode (no auto-insert)
+        if (event.isCharIgnoreCase('j') && !isTextFieldFocused()) {
+            if (mainScreen.getFocusArea() == MainScreen.FocusArea.DEPENDENCIES) {
+                mainScreen.getDependencyPicker().moveDown();
+            } else {
+                mainScreen.focusNext();
+                vimInsertMode = false;
+                mainScreen.setInsertMode(false);
             }
             return EventResult.HANDLED;
         }
@@ -356,11 +408,15 @@ public class SpringInitializrTui extends ToolkitApp {
         return EventResult.UNHANDLED;
     }
 
-    private boolean isTextFieldFocused() {
+    private boolean isOnTextFieldArea() {
         return mainScreen != null && switch (mainScreen.getFocusArea()) {
             case GROUP, ARTIFACT, NAME, DESCRIPTION -> true;
             default -> false;
         };
+    }
+
+    private boolean isTextFieldFocused() {
+        return vimInsertMode && isOnTextFieldArea();
     }
 
     private static final Set<String> SKIP_EXTENSIONS = Set.of(

--- a/src/main/java/dev/danvega/initializr/ui/HelpScreen.java
+++ b/src/main/java/dev/danvega/initializr/ui/HelpScreen.java
@@ -30,6 +30,8 @@ public class HelpScreen {
                                 shortcutRow("x", "Clear all dependencies"),
                                 shortcutRow("e", "Explore generated project"),
                                 shortcutRow("g", "Generate and download project"),
+                                shortcutRow("i", "Enter insert mode (text fields)"),
+                                shortcutRow("Esc", "Exit insert mode \u2192 normal mode"),
                                 shortcutRow("?", "Show this help screen"),
                                 shortcutRow("q / Ctrl+C", "Quit"),
                                 text(""),

--- a/src/main/java/dev/danvega/initializr/ui/MainScreen.java
+++ b/src/main/java/dev/danvega/initializr/ui/MainScreen.java
@@ -23,6 +23,7 @@ public class MainScreen {
     private final InitializrMetadata.SelectField appFormatField;
     private FocusArea focusArea = FocusArea.PROJECT_TYPE;
     private boolean searchMode = false;
+    private boolean insertMode = false;
     private StringBuilder searchBuffer = new StringBuilder();
 
     public MainScreen(InitializrMetadata.Metadata metadata, ProjectConfig config,
@@ -44,6 +45,7 @@ public class MainScreen {
     public FocusArea getFocusArea() { return focusArea; }
     public DependencyPicker getDependencyPicker() { return dependencyPicker; }
     public boolean isSearchMode() { return searchMode; }
+    public void setInsertMode(boolean insertMode) { this.insertMode = insertMode; }
 
     public void enterSearchMode() {
         searchMode = true;
@@ -241,7 +243,8 @@ public class MainScreen {
     private Element renderTextRow(String label, String value, boolean focused) {
         var t = ThemeManager.current();
         String paddedLabel = String.format("  %-12s", label);
-        String displayValue = focused ? "[ " + value + "_ ]" : "[ " + value + " ]";
+        String cursor = (focused && !insertMode) ? "\u258c" : (focused ? "_" : " ");
+        String displayValue = "[ " + value + cursor + " ]";
 
         return row(
                 text(paddedLabel).fg(focused ? t.text() : t.textDim()).bold(),
@@ -311,6 +314,13 @@ public class MainScreen {
 
     private Element renderFooter() {
         var t = ThemeManager.current();
+        if (insertMode) {
+            return row(
+                    text("  -- INSERT --").fg(t.primary()).bold(),
+                    text("  Esc").fg(t.text()), text(":normal mode").fg(t.textDim()),
+                    spacer()
+            ).length(1);
+        }
         return row(
                 text("  Tab").fg(t.text()), text(":navigate  ").fg(t.textDim()),
                 text("/").fg(t.text()), text(":search  ").fg(t.textDim()),
@@ -318,6 +328,7 @@ public class MainScreen {
                 text("\u2190\u2192").fg(t.text()), text(":change  ").fg(t.textDim()),
                 text("c").fg(t.text()), text(":filter  ").fg(t.textDim()),
                 text("x").fg(t.text()), text(":clear  ").fg(t.textDim()),
+                text("i").fg(t.text()), text(":insert  ").fg(t.textDim()),
                 text("?").fg(t.text()), text(":help  ").fg(t.textDim()),
                 text("q").fg(t.text()), text(":quit").fg(t.textDim()),
                 spacer()


### PR DESCRIPTION
 Builds on the existing vim navigation (PR #10) to add a proper insert/normal mode distinction for text field editing.

 - When pressing `i`, it enters INSERT mode when focused on a text field (Group, Artifact, Name, Description). And then pressing `Esc` returns back to normal mode
 - The arrow keys retain their original behavior. However, they auto-enter insert mode when navigating onto a text field
 - The vim `j`/`k` motion keys will never auto-enter insert mode and navigation will stay in normal mode until the user presses the `i` key
 - I put a cursor (`▌`) which is shown on a focused text field in normal mode and an underscore (`_`) which is shown in insert mode
 -  The footer swaps to `-- INSERT --` mode and then shows an `Esc:normal mode` hint
 - I added an `i:insert` hint to the normal footer
 -  -  - 
 - Refactored `isTextFieldFocused()` into two helpers: `isOnTextFieldArea()` (focus position) and `isTextFieldFocused()` (position + insert mode) making the intent clearer at each call site
 -  -  - 
 - Help screen updated with `i` and `Esc` insert mode entries

This change is friendly for all users